### PR TITLE
Generic: import everything from Monoid for older GHCs

### DIFF
--- a/src/Data/Text/Zipper/Generic.hs
+++ b/src/Data/Text/Zipper/Generic.hs
@@ -11,7 +11,7 @@ import qualified Data.Text as T
 import qualified Data.Text.Zipper.Vector as V
 import qualified Data.Vector as V
 
-import           Data.Monoid ()
+import           Data.Monoid
 
 import           Data.Text.Zipper
 


### PR DESCRIPTION
Hopefully you haven't published the 0.7 release yet. It looks like there was a build failure on older GHCs that don't have Monoid in Prelude.
