### PR TITLE
text-zipper.cabal: include hspec-discover as build tool

### DIFF
--- a/text-zipper.cabal
+++ b/text-zipper.cabal
@@ -41,6 +41,7 @@ test-suite text-zipper-tests
   main-is:             Main.hs
   other-modules:       WordsSpec
   default-language:    Haskell2010
+  build-tool-depends:  hspec-discover:hspec-discover
   build-depends:       base,
                        text,
                        hspec,


### PR DESCRIPTION
It is technically required to run the tests.